### PR TITLE
Add Universidad Tecnológica El Retoño (utr.edu.mx)

### DIFF
--- a/lib/domains/mx/edu/utr.txt
+++ b/lib/domains/mx/edu/utr.txt
@@ -1,0 +1,1 @@
+Universidad Tecnológica El Retoño


### PR DESCRIPTION
Se solicita añadir el dominio utr.edu.mx de la Universidad Tecnológica El Retoño.